### PR TITLE
fix(macOS): resolve BIOS path correctly on macOS

### DIFF
--- a/ManicEmu/ManicEmu/Sources/Tools/Extensions/StringExtensions.swift
+++ b/ManicEmu/ManicEmu/Sources/Tools/Extensions/StringExtensions.swift
@@ -302,7 +302,10 @@ extension String {
     }
     
     var libretroPath: String {
-        if let range = self.range(of: "/Documents/") ?? self.range(of: "/Library/") {
+        // Use .backwards for "/Library/" to match the app's Library directory,
+        // not the user's ~/Library on macOS where the container path contains
+        // "/Library/" twice (e.g., /Users/X/Library/Containers/.../Data/Library/...)
+        if let range = self.range(of: "/Documents/") ?? self.range(of: "/Library/", options: .backwards) {
             return "~" + String(self[range.lowerBound...])
         }
         return self


### PR DESCRIPTION
## Summary
- Fix `libretroPath` in `StringExtensions.swift` to use `.backwards` option when matching `/Library/`, so it matches the app's Library directory instead of the user's `~/Library` on macOS

## Problem
On macOS, the sandbox container path contains `/Library/` twice:
```
/Users/X/Library/Containers/{UUID}/Data/Library/Libretro/system
         ^^^^^^^^ (1st match — wrong)              ^^^^^^^^ (correct)
```

`String.range(of: "/Library/")` matched the **first** occurrence, producing:
```
~/Library/Containers/{UUID}/Data/Library/Libretro/system
```

This path is written to `retroarch.cfg` as `system_directory`. Since RetroArch's C backend does not expand `~` for this setting, the Beetle PSX HW core receives a literal path that doesn't exist → **"Firmware is missing: scph5500.bin"** error.

On iOS, this works correctly because the container path only contains `/Library/` once.

## Fix
```diff
- if let range = self.range(of: "/Documents/") ?? self.range(of: "/Library/") {
+ if let range = self.range(of: "/Documents/") ?? self.range(of: "/Library/", options: .backwards) {
```

Using `.backwards` ensures the **last** `/Library/` is matched (the app's Library), producing the correct path:
```
~/Library/Libretro/system ✅
```

## Test plan
- [ ] Verify PS1 games launch on macOS with imported BIOS (scph5500.bin / ps1_rom.bin)
- [ ] Verify PS1 games still launch on iOS (no regression)
- [ ] Verify other systems using Libretro cores work on macOS (PPSSPP, 3DS, etc.)

Closes #40