### PR TITLE
fix(sync): upload companion files for multi-file ROMs to iCloud

### DIFF
--- a/ManicEmu/ManicEmu/Sources/Tools/Others/FilesImporter.swift
+++ b/ManicEmu/ManicEmu/Sources/Tools/Others/FilesImporter.swift
@@ -444,6 +444,11 @@ extension FilesImporter {
                                 for item in items {
                                     try FileManager.safeCopyItem(at: item, to: URL(fileURLWithPath: romParentPath.appendingPathComponent(item.lastPathComponent)), shouldReplace: true)
                                 }
+                                // Upload all files (main + companions) to iCloud
+                                SyncManager.upload(localFilePath: romUrl.path)
+                                for item in items {
+                                    SyncManager.upload(localFilePath: romParentPath.appendingPathComponent(item.lastPathComponent))
+                                }
                             } else {
                                 try FileManager.safeCopyItem(at: url, to: game.romUrl, shouldReplace: true)
                                 //文件复制成功
@@ -513,6 +518,13 @@ extension FilesImporter {
                             do {
                                 try realm.write { realm.add(game) }
                                 SyncManager.upload(localFilePath: game.romUrl.path)
+                                // Upload companion files (.bin, .img, .sub, etc.) for multi-file ROMs
+                                if items.count > 0 {
+                                    let romParentPath = game.romUrl.path.deletingLastPathComponent
+                                    for item in items {
+                                        SyncManager.upload(localFilePath: romParentPath.appendingPathComponent(item.lastPathComponent))
+                                    }
+                                }
                                 OnlineCoverManager.shared.addCoverMatch(OnlineCoverManager.CoverMatch(game: game))
                                 completion?(game.gameType == ._3ds ? (game.aliasName ?? game.name) : game.name, nil)
                                 


### PR DESCRIPTION
## Summary
- Upload companion files (.bin, .img, .sub, etc.) to iCloud when importing multi-file ROMs

## Problem
When importing a multi-file ROM (e.g., PS1 `.cue` + `.bin`), only the main file (`.cue`) was uploaded to iCloud. The companion files (`.bin` track data) were copied locally but `SyncManager.upload()` was never called for them.

This caused other devices to sync only the `.cue` file with no actual game data — the game could not launch on the synced device.

### Before (broken)
```swift
// FilesImporter.swift line 515 — only main file uploaded
SyncManager.upload(localFilePath: game.romUrl.path)  // .cue only
// ❌ .bin files silently skipped
```

### After (fixed)
```swift
SyncManager.upload(localFilePath: game.romUrl.path)
// ✅ Upload companion files (.bin, .img, .sub, etc.)
if items.count > 0 {
    let romParentPath = game.romUrl.path.deletingLastPathComponent
    for item in items {
        SyncManager.upload(localFilePath: romParentPath.appendingPathComponent(item.lastPathComponent))
    }
}
```

The fix is applied to both code paths:
1. **New game import** (line ~515) — when a game is first added
2. **Existing game restore** (line ~439) — when ROM files are re-imported for an existing database entry

Note: The **delete** logic already correctly handles multi-file ROMs via `SyncManager.deletePath(localPath: romParentPath)` which removes the entire directory.

## Affected systems
| System | Main file | Companion files (previously not synced) |
|--------|-----------|----------------------------------------|
| PS1 | `.cue` | `.bin` (one or more tracks) |
| Saturn | `.cue` | `.bin` |
| Mega CD | `.cue` | `.bin` |
| Dreamcast | `.gdi` | `.bin` (track files) |
| Any | `.ccd` | `.img`, `.sub` |

## Test plan
- [ ] Import a PS1 game (.cue + .bin) on device A, verify .bin files appear in iCloud
- [ ] Sync to device B, verify the game launches successfully
- [ ] Import a multi-disc game (.m3u + multiple .cue/.bin), verify all files sync
- [ ] Verify single-file ROMs (.chd, .pbp) still work correctly (no regression)

Closes #42