### PR TITLE
fix(cheat): use '+' separator for libretro cheats and fix auto-detect logic

### DIFF
--- a/ManicEmu/ManicEmu/Sources/Business/CheatCode/Views/AddCheatCodeView.swift
+++ b/ManicEmu/ManicEmu/Sources/Business/CheatCode/Views/AddCheatCodeView.swift
@@ -332,8 +332,6 @@ class AddCheatCodeView: BaseView {
                 }
                 if isMatchThisFormat {
                     return (formatString, cheatFormat)
-                } else {
-                    return nil
                 }
             }
         }

--- a/ManicEmu/ManicEmu/Sources/Business/Play/VIewControllers/PlayViewController.swift
+++ b/ManicEmu/ManicEmu/Sources/Business/Play/VIewControllers/PlayViewController.swift
@@ -2228,13 +2228,15 @@ extension PlayViewController {
                     LibretroCore.sharedInstance().resetCheatCode()
                     for (index, cheatCode) in self.manicGame.gameCheats.enumerated() {
                         if cheatCode.activate {
+                            // Convert newline separators to '+' (libretro standard for multi-line cheats)
+                            let coreCode: String
                             if CheatType(cheatCode.type) == .actionReplay16, self.manicGame.isPicodriveCore, cheatCode.code.count > 6 {
                                 //MD不支持0123456789格式的作弊码，需要转换成012345:6789格式
-                                let processedCode = cheatCode.code[...5] + ":" + cheatCode.code[6...]
-                                LibretroCore.sharedInstance().addCheatCode(String(processedCode), index: UInt32(index), enable: true)
+                                coreCode = cheatCode.code[...5] + ":" + cheatCode.code[6...]
                             } else {
-                                LibretroCore.sharedInstance().addCheatCode(cheatCode.code, index: UInt32(index), enable: true)
+                                coreCode = cheatCode.code.replacingOccurrences(of: "\n", with: "+")
                             }
+                            LibretroCore.sharedInstance().addCheatCode(String(coreCode), index: UInt32(index), enable: true)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Replace newline separators with `+` (libretro standard) when sending multi-line cheats to cores
- Fix auto-detect format loop that returned `nil` after first non-matching format

## Bug 1: Cheat separator mismatch (all libretro cores)

`CheatFormat.formatted(with:)` joins multi-line cheats with `\n`, but all libretro cores expect `+` as the multi-line separator.

**Example** (SNES Game Genie):
- ManicEmu sends: `ABCD-EFGH\nIJKL-MNOP`
- Core expects: `ABCD-EFGH+IJKL-MNOP`
- Result: decode failure, cheat silently ignored

This affects **all libretro-based systems**: SNES, PS1, N64, Genesis, Saturn, etc.

### Fix
```diff
 // PlayViewController.swift line 2236
-LibretroCore.sharedInstance().addCheatCode(cheatCode.code, ...)
+let coreCode = cheatCode.code.replacingOccurrences(of: "\n", with: "+")
+LibretroCore.sharedInstance().addCheatCode(String(coreCode), ...)
```

## Bug 2: Auto-detect only checks first format

`AddCheatCodeView.checkCheat()` returned `nil` on the first non-matching format instead of continuing the loop:

### Fix
```diff
 if isMatchThisFormat {
     return (formatString, cheatFormat)
-} else {
-    return nil
 }
+// Loop continues to try next format
```

## Test plan
- [ ] Enter a multi-line Game Genie cheat for SNES — verify it takes effect
- [ ] Enter a GameShark cheat for PS1 — verify it takes effect
- [ ] Enter a Pro Action Replay cheat for Genesis — verify it takes effect
- [ ] Use auto-detect with a PAR code when Game Genie is listed first — verify it is correctly detected
- [ ] Single-line cheats still work (no regression)

Closes #47